### PR TITLE
finish Project Tasks view + modals

### DIFF
--- a/client/src/app/components/Header/index.tsx
+++ b/client/src/app/components/Header/index.tsx
@@ -2,11 +2,11 @@ import React from "react";
 
 type Props = {
   name: string;
-  // buttonComponent?
+  buttonComponent?: any;
   isSmallText?: boolean;
 };
 
-const Header = ({ name, isSmallText = false }: Props) => {
+const Header = ({ name, buttonComponent, isSmallText = false }: Props) => {
   return (
     <div className="w-ful mb-5 flex items-center justify-between">
       <h1
@@ -14,6 +14,7 @@ const Header = ({ name, isSmallText = false }: Props) => {
       >
         {name}
       </h1>
+      {buttonComponent}
     </div>
   );
 };

--- a/client/src/app/components/Modal/index.tsx
+++ b/client/src/app/components/Modal/index.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import ReactDOM from "react-dom";
+import Header from "../Header";
+import { X } from "lucide-react";
+
+type ModalProps = {
+  children: React.ReactNode;
+  isOpen: boolean;
+  onClose: () => void;
+  name: string;
+};
+
+const Modal = ({ children, isOpen, onClose, name }: ModalProps) => {
+  if (!isOpen) return null;
+  return ReactDOM.createPortal(
+    <div className="fixed inset-0 flex h-full w-full items-center justify-center overflow-y-auto bg-gray-600 bg-opacity-50 p-4">
+      <div className="w-full max-w-2xl rounded-lg bg-white p-4 shadow-lg dark:bg-dark-secondary">
+        <Header
+          name={name}
+          buttonComponent={
+            <button
+              className="flex h-7 w-7 items-center justify-center rounded-full bg-blue-primary text-white hover:bg-blue-600"
+              onClick={onClose}
+            >
+              <X size={18} />
+            </button>
+          }
+          isSmallText
+        />
+        {children}
+      </div>
+    </div>,
+    document.body,
+  );
+};
+
+export default Modal;

--- a/client/src/app/components/ModalNewTask/index.tsx
+++ b/client/src/app/components/ModalNewTask/index.tsx
@@ -1,0 +1,169 @@
+import Modal from "@/app/components/Modal";
+import { Priority, Status, useCreateTaskMutation } from "@/state/api";
+import React, { useState } from "react";
+import { formatISO } from "date-fns";
+
+type ModalNewTaskProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  id: string;
+};
+
+const ModalNewTask = ({ isOpen, onClose, id }: ModalNewTaskProps) => {
+  const [createTask, { isLoading }] = useCreateTaskMutation();
+
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [status, setStatus] = useState<Status>(Status.ToDo);
+  const [priority, setPriority] = useState<Priority>(Priority.Backlog);
+  const [tags, setTags] = useState("");
+  const [startDate, setStartDate] = useState("");
+  const [dueDate, setDueDate] = useState("");
+  const [authorUserId, setAuthorUserId] = useState("");
+  const [assignedUserId, setAssignedUserId] = useState("");
+  const [projectId, setProjectId] = useState("");
+
+  const handleSubmit = async () => {
+    if (!title || !authorUserId || !startDate || !dueDate) return;
+
+    const formattedStartDate = formatISO(new Date(startDate), {
+      representation: "complete",
+    });
+    const formattedDueDate = formatISO(new Date(dueDate), {
+      representation: "complete",
+    });
+
+    await createTask({
+      title,
+      description,
+      status,
+      priority,
+      tags,
+      startDate: startDate || formattedStartDate,
+      dueDate: dueDate || formattedDueDate,
+      authorUserId: parseInt(authorUserId),
+      assignedUserId: parseInt(assignedUserId),
+      projectId: Number(id),
+    });
+  };
+
+  const isFormValid = () => {
+    return title && authorUserId && startDate && dueDate;
+  };
+
+  const selectStyles =
+    "mb-4 block w-full rounded border border-gray-300 px-3 py-2 dark:border-dark-tertiary dark:bg-dark-tertiary dark:text-white dark:focus:outline-none";
+
+  const inputStyles =
+    "w-full rounded border border-gray-300 p-2 shadow-sm dark:border-dark-tertiary dark:bg-dark-tertiary dark:text-white dark:focus:outline-none";
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} name="Create New Task">
+      <form
+        className="mt-4 space-y-6"
+        onSubmit={(event) => {
+          event.preventDefault();
+          handleSubmit();
+        }}
+      >
+        <input
+          type="text"
+          className={inputStyles}
+          placeholder="Title"
+          value={title}
+          onChange={(event) => setTitle(event.target.value)}
+        />
+        <textarea
+          className={inputStyles}
+          placeholder="Description"
+          value={description}
+          onChange={(event) => setDescription(event.target.value)}
+        />
+        <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 sm:gap-2">
+          <select
+            className={selectStyles}
+            value={status}
+            onChange={(event) =>
+              setStatus(Status[event.target.value as keyof typeof Status])
+            }
+          >
+            <option value="">Select Status</option>
+            <option value={Status.ToDo}>To Do</option>
+            <option value={Status.WorkInProgress}>Work In Progress</option>
+            <option value={Status.UnderReview}>Under Review</option>
+            <option value={Status.Completed}>Completed</option>
+          </select>
+          <select
+            className={selectStyles}
+            value={priority}
+            onChange={(event) =>
+              setPriority(Priority[event.target.value as keyof typeof Priority])
+            }
+          >
+            <option value="">Select Priority</option>
+            <option value={Priority.Urgent}>Urgent</option>
+            <option value={Priority.High}>High</option>
+            <option value={Priority.Medium}>Medium</option>
+            <option value={Priority.Low}>Low</option>
+            <option value={Priority.Backlog}>Backlog</option>
+          </select>
+        </div>
+
+        <input
+          type="text"
+          className={inputStyles}
+          placeholder="Tags (comma separated)"
+          value={tags}
+          onChange={(event) => setTags(event.target.value)}
+        />
+
+        <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 sm:gap-2">
+          <input
+            type="date"
+            className={inputStyles}
+            value={startDate}
+            onChange={(event) => setStartDate(event.target.value)}
+          />
+          <input
+            type="date"
+            className={inputStyles}
+            value={dueDate}
+            onChange={(event) => setDueDate(event.target.value)}
+          />
+        </div>
+        <input
+          type="text"
+          className={inputStyles}
+          placeholder="Author User ID"
+          value={authorUserId}
+          onChange={(event) => setAuthorUserId(event.target.value)}
+        />
+        <input
+          type="text"
+          className={inputStyles}
+          placeholder="Assigned User ID"
+          value={assignedUserId}
+          onChange={(event) => setAssignedUserId(event.target.value)}
+        />
+        {id === null && (
+          <input
+            type="text"
+            className={inputStyles}
+            placeholder="Project ID"
+            value={projectId}
+            onChange={(event) => setProjectId(event.target.value)}
+          />
+        )}
+        <button
+          type="submit"
+          className={`focus-offset-2 mt-4 flex w-full justify-center rounded-md border border-transparent bg-blue-primary px-4 py-2 text-base font-medium text-white shadow-sm hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-600 ${!isFormValid() || isLoading ? "cursor-not-allowed opacity-50" : ""}`}
+          disabled={!isFormValid() || isLoading}
+        >
+          {isLoading ? "Creating..." : "Create Task"}
+        </button>
+      </form>
+    </Modal>
+  );
+};
+
+export default ModalNewTask;

--- a/client/src/app/components/TaskCard/index.tsx
+++ b/client/src/app/components/TaskCard/index.tsx
@@ -1,0 +1,73 @@
+import { Task } from "@/state/api";
+import Image from "next/image";
+import React from "react";
+import { format } from "date-fns";
+
+type TaskCardProps = {
+  task: Task;
+};
+
+const TaskCard = ({ task }: TaskCardProps) => {
+  const formattedStartDate = task.startDate
+    ? format(new Date(task.startDate), "dd-MM-yyyy")
+    : "Not set";
+  const formattedDueDate = task.dueDate
+    ? format(new Date(task.dueDate), "dd-MM-yyyy")
+    : "Not set";
+
+  return (
+    <div className="mb-3 rounded bg-white p-4 shadow dark:bg-dark-secondary dark:text-white">
+      <p>
+        <strong>ID: {task.id}</strong>
+      </p>
+      <p>
+        <strong>Title:</strong> {task.title}
+      </p>
+      <p>
+        <strong>Description:</strong>{" "}
+        {task.description || "No description provided"}
+      </p>
+      <p>
+        <strong>Status:</strong> {task.status}
+      </p>
+      <p>
+        <strong>Priority:</strong> {task.priority}
+      </p>
+      <p>
+        <strong>Tags:</strong> {task.tags || "No tags "}
+      </p>
+      <p>
+        <strong>Start Date:</strong> {formattedStartDate}
+      </p>
+      <p>
+        <strong>Due Date:</strong> {formattedDueDate}
+      </p>
+      <p>
+        <strong>Author:</strong>{" "}
+        {task.author ? task.author.username : "Unknown"}
+      </p>
+      <p>
+        <strong>Assignee:</strong>{" "}
+        {task.assignee ? task.assignee.username : "Unassigned"}
+      </p>
+      {task.attachments && task.attachments.length > 0 && (
+        <div>
+          <strong>Attachments:</strong>
+          <div className="flex flex-wrap">
+            {task.attachments && task.attachments.length && (
+              <Image
+                src={`/${task.attachments[0].fileURL}`}
+                alt={task.attachments[0].fileName}
+                width={400}
+                height={200}
+                className="mt-1 rounded-md"
+              />
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default TaskCard;

--- a/client/src/app/globals.css
+++ b/client/src/app/globals.css
@@ -19,3 +19,54 @@ body,
   @apply bg-white;
   @apply dark:bg-black;
 }
+
+/* Timeline styling */
+.timeline ._3_ygE {
+  @apply rounded-tl-md border border-r-0 border-[#e6e4e4] dark:border-stroke-dark;
+}
+
+.timeline ._2eZzQ {
+  @apply border-[#e6e4e4] dark:border-stroke-dark;
+}
+
+.timeline ._2dZTy {
+  @apply fill-white dark:fill-dark-secondary;
+}
+
+.timeline ._2dZTy:nth-child(even) {
+  @apply fill-[#f5f5f5] dark:fill-dark-tertiary;
+}
+
+.timeline ._35nLX {
+  @apply fill-white stroke-[#e6e4e4] dark:fill-dark-secondary dark:stroke-stroke-dark;
+}
+
+.timeline ._9w8d5 {
+  @apply fill-[#333] dark:fill-white;
+}
+
+.timeline ._34SS0 {
+  @apply bg-white dark:bg-dark-secondary;
+}
+
+.timeline ._34SS0:nth-of-type(even) {
+  @apply bg-[#f5f5f5] dark:bg-dark-tertiary;
+}
+
+.timeline ._RuwuK,
+.timeline ._3rUKi,
+.timeline ._1rLuZ {
+  @apply stroke-[#e6e4e4] dark:stroke-stroke-dark;
+}
+
+.timeline ._3ZbQT {
+  @apply border-l-0 border-[#e6e4e4] dark:border-stroke-dark;
+}
+
+.timeline ._3T42e {
+  @apply bg-white dark:bg-dark-bg;
+}
+
+.timeline ._29NTg {
+  @apply dark:text-neutral-500;
+}

--- a/client/src/app/projects/BoardView/index.tsx
+++ b/client/src/app/projects/BoardView/index.tsx
@@ -10,11 +10,12 @@ import { format } from "date-fns";
 
 type BoardProps = {
   id: string;
+  setIsModalNewTaskOpen: (isOpen: boolean) => void;
 };
 
 const taskStatus = ["To Do", "Work In Progress", "Under Review", "Completed"];
 
-const BoardView = ({ id }: BoardProps) => {
+const BoardView = ({ id, setIsModalNewTaskOpen }: BoardProps) => {
   const {
     data: tasks,
     isLoading,
@@ -39,6 +40,7 @@ const BoardView = ({ id }: BoardProps) => {
             status={status}
             tasks={tasks || []}
             moveTask={moveTask}
+            setIsModalNewTaskOpen={setIsModalNewTaskOpen}
           />
         ))}
       </div>
@@ -51,9 +53,15 @@ type TaskColumnProps = {
   status: string;
   tasks: TaskType[];
   moveTask: (taskId: number, toStatus: string) => void;
+  setIsModalNewTaskOpen: (isOpen: boolean) => void;
 };
 
-const TaskColumn = ({ status, tasks, moveTask }: TaskColumnProps) => {
+const TaskColumn = ({
+  status,
+  tasks,
+  moveTask,
+  setIsModalNewTaskOpen,
+}: TaskColumnProps) => {
   const [{ isOver }, drop] = useDrop(() => ({
     accept: "task",
     drop: (item: { id: number }) => moveTask(item.id, status),
@@ -99,7 +107,10 @@ const TaskColumn = ({ status, tasks, moveTask }: TaskColumnProps) => {
             <button className="flex h-6 w-5 items-center justify-center dark:text-neutral-500">
               <EllipsisVertical size={26} />
             </button>
-            <button className="flex h-6 w-6 items-center justify-center rounded bg-gray-200 dark:bg-dark-tertiary dark:text-white">
+            <button
+              className="flex h-6 w-6 items-center justify-center rounded bg-gray-200 dark:bg-dark-tertiary dark:text-white"
+              onClick={() => setIsModalNewTaskOpen(true)}
+            >
               <Plus size={16} />
             </button>
           </div>

--- a/client/src/app/projects/ListView/index.tsx
+++ b/client/src/app/projects/ListView/index.tsx
@@ -1,0 +1,32 @@
+import Header from "@/app/components/Header";
+import TaskCard from "@/app/components/TaskCard";
+import { Task, useGetTasksQuery } from "@/state/api";
+import React from "react";
+
+type ListProps = {
+  id: string;
+};
+
+const ListView = ({ id }: ListProps) => {
+  const {
+    data: tasks,
+    error,
+    isLoading,
+  } = useGetTasksQuery({ projectId: Number(id) });
+
+  if (isLoading) return <div>Loading...</div>;
+  if (error) return <div>An error occured while fetching tasks</div>;
+
+  return (
+    <div className="px-4 pb-8 xl:px-6">
+      <div className="pt-5">
+        <Header name="List" />
+      </div>
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3 lg:gap-6">
+        {tasks?.map((task: Task) => <TaskCard key={task.id} task={task} />)}
+      </div>
+    </div>
+  );
+};
+
+export default ListView;

--- a/client/src/app/projects/ListView/index.tsx
+++ b/client/src/app/projects/ListView/index.tsx
@@ -20,7 +20,18 @@ const ListView = ({ id }: ListProps) => {
   return (
     <div className="px-4 pb-8 xl:px-6">
       <div className="pt-5">
-        <Header name="List" />
+        <Header
+          name="List"
+          buttonComponent={
+            <button
+              className="flex items-center rounded bg-blue-primary px-3 py-2 text-white hover:bg-blue-600"
+              //TODO: onClick={()=>{}}
+            >
+              Add Task
+            </button>
+          }
+          isSmallText
+        />
       </div>
       <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3 lg:gap-6">
         {tasks?.map((task: Task) => <TaskCard key={task.id} task={task} />)}

--- a/client/src/app/projects/ListView/index.tsx
+++ b/client/src/app/projects/ListView/index.tsx
@@ -5,9 +5,10 @@ import React from "react";
 
 type ListProps = {
   id: string;
+  setIsModalNewTaskOpen: (isOpen: boolean) => void;
 };
 
-const ListView = ({ id }: ListProps) => {
+const ListView = ({ id, setIsModalNewTaskOpen }: ListProps) => {
   const {
     data: tasks,
     error,
@@ -25,7 +26,7 @@ const ListView = ({ id }: ListProps) => {
           buttonComponent={
             <button
               className="flex items-center rounded bg-blue-primary px-3 py-2 text-white hover:bg-blue-600"
-              //TODO: onClick={()=>{}}
+              onClick={() => setIsModalNewTaskOpen(true)}
             >
               Add Task
             </button>

--- a/client/src/app/projects/ModalNewProject/index.tsx
+++ b/client/src/app/projects/ModalNewProject/index.tsx
@@ -1,0 +1,92 @@
+import Modal from "@/app/components/Modal";
+import { useCreateProjectMutation } from "@/state/api";
+import React, { useState } from "react";
+import { formatISO } from "date-fns";
+
+type ModalNewProjectProps = {
+  isOpen: boolean;
+  onClose: () => void;
+};
+
+const ModalNewProject = ({ isOpen, onClose }: ModalNewProjectProps) => {
+  const [createProject, { isLoading }] = useCreateProjectMutation();
+
+  const [projectName, setProjectName] = useState("");
+  const [description, setDescription] = useState("");
+  const [startDate, setStartDate] = useState("");
+  const [endDate, setEndDate] = useState("");
+
+  const handleSubmit = async () => {
+    if (!projectName || !startDate || !endDate) return;
+
+    const formattedStartDate = formatISO(new Date(startDate), {
+      representation: "complete",
+    });
+    const formattedEndDate = formatISO(new Date(endDate), {
+      representation: "complete",
+    });
+
+    await createProject({
+      name: projectName,
+      description,
+      startDate: formattedStartDate,
+      endDate: formattedEndDate,
+    });
+  };
+
+  const isFormValid = () => {
+    return projectName && description && startDate && endDate;
+  };
+
+  const inputStyles =
+    "w-full rounded border border-gray-300 p-2 shadow-sm dark:border-dark-tertiary dark:bg-dark-tertiary dark:text-white dark:focus:outline-none";
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} name="Create New Project">
+      <form
+        className="mt-4 space-y-6"
+        onSubmit={(event) => {
+          event.preventDefault();
+          handleSubmit();
+        }}
+      >
+        <input
+          type="text"
+          className={inputStyles}
+          placeholder="Project Name"
+          value={projectName}
+          onChange={(event) => setProjectName(event.target.value)}
+        />
+        <textarea
+          className={inputStyles}
+          placeholder="Description"
+          value={description}
+          onChange={(event) => setDescription(event.target.value)}
+        />
+        <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 sm:gap-2">
+          <input
+            type="date"
+            className={inputStyles}
+            value={startDate}
+            onChange={(event) => setStartDate(event.target.value)}
+          />
+          <input
+            type="date"
+            className={inputStyles}
+            value={endDate}
+            onChange={(event) => setEndDate(event.target.value)}
+          />
+        </div>
+        <button
+          type="submit"
+          className={`focus-offset-2 mt-4 flex w-full justify-center rounded-md border border-transparent bg-blue-primary px-4 py-2 text-base font-medium text-white shadow-sm hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-600 ${!isFormValid() || isLoading ? "cursor-not-allowed opacity-50" : ""}`}
+          disabled={!isFormValid() || isLoading}
+        >
+          {isLoading ? "Creating..." : "Create Project"}
+        </button>
+      </form>
+    </Modal>
+  );
+};
+
+export default ModalNewProject;

--- a/client/src/app/projects/ProjectHeader.tsx
+++ b/client/src/app/projects/ProjectHeader.tsx
@@ -1,7 +1,16 @@
-import React from "react";
+import React, { useState } from "react";
 
 import Header from "../components/Header";
-import { Clock, Filter, Grid3x3, List, Share2, Table } from "lucide-react";
+import {
+  Clock,
+  Filter,
+  Grid3x3,
+  List,
+  PlusSquare,
+  Share2,
+  Table,
+} from "lucide-react";
+import ModalNewProject from "./ModalNewProject";
 
 type Props = {
   activeTab: string;
@@ -9,11 +18,27 @@ type Props = {
 };
 
 const ProjectHeader = ({ activeTab, setActiveTab }: Props) => {
+  const [isModalNewProjectOpen, setIsModalNewProjectOpen] = useState(false);
+
   return (
     <div className="px-4 xl:px-6">
       {/* Modal NEW PROJECT */}
+      <ModalNewProject
+        isOpen={isModalNewProjectOpen}
+        onClose={() => setIsModalNewProjectOpen(false)}
+      />
       <div className="pb-6 pt-6 lg:pb-4 lg:pt-8">
-        <Header name="Product Design" />
+        <Header
+          name="Product Design"
+          buttonComponent={
+            <button
+              className="flex items-center rounded-md bg-blue-primary px-3 py-2 text-white hover:bg-blue-600"
+              onClick={() => setIsModalNewProjectOpen(true)}
+            >
+              <PlusSquare className="mr-2 h-5 w-5" /> New Project
+            </button>
+          }
+        />
       </div>
 
       {/* Tabs */}

--- a/client/src/app/projects/TableView/index.tsx
+++ b/client/src/app/projects/TableView/index.tsx
@@ -7,6 +7,7 @@ import { useAppSelector } from "@/app/redux";
 
 type TableViewProps = {
   id: string;
+  setIsModalNewTaskOpen: (isOpen: boolean) => void;
 };
 
 const columns: GridColDef[] = [
@@ -64,7 +65,7 @@ const columns: GridColDef[] = [
   },
 ];
 
-const TableView = ({ id }: TableViewProps) => {
+const TableView = ({ id, setIsModalNewTaskOpen }: TableViewProps) => {
   const isDarkMode = useAppSelector((state) => state.global.isDarkMode);
   const {
     data: tasks,
@@ -83,7 +84,7 @@ const TableView = ({ id }: TableViewProps) => {
           buttonComponent={
             <button
               className="flex items-center rounded bg-blue-primary px-3 py-2 text-white hover:bg-blue-600"
-              //TODO: onClick={()=>{}}
+              onClick={() => setIsModalNewTaskOpen(true)}
             >
               Add Task
             </button>

--- a/client/src/app/projects/TableView/index.tsx
+++ b/client/src/app/projects/TableView/index.tsx
@@ -1,0 +1,94 @@
+import Header from "@/app/components/Header";
+import { useGetTasksQuery } from "@/state/api";
+import React from "react";
+import { DataGrid, GridColDef } from "@mui/x-data-grid";
+import { dataGridClassNames, dataGridSxStyles } from "@/lib/utils";
+import { useAppSelector } from "@/app/redux";
+
+type TableViewProps = {
+  id: string;
+};
+
+const columns: GridColDef[] = [
+  {
+    field: "title",
+    headerName: "Title",
+    width: 100,
+  },
+  {
+    field: "description",
+    headerName: "Description",
+    width: 200,
+  },
+  {
+    field: "status",
+    headerName: "Status",
+    width: 130,
+    renderCell: (params) => (
+      <span className="inline-flex rounded-full bg-green-100 px-2 text-xs font-semibold leading-5 text-green-800">
+        {params.value}
+      </span>
+    ),
+  },
+  {
+    field: "priority",
+    headerName: "Priority",
+    width: 75,
+  },
+  {
+    field: "tags",
+    headerName: "Tags",
+    width: 130,
+  },
+  {
+    field: "startDate",
+    headerName: "Start Date",
+    width: 130,
+  },
+  {
+    field: "dueDate",
+    headerName: "Due Date",
+    width: 130,
+  },
+  {
+    field: "author",
+    headerName: "Author",
+    width: 150,
+    renderCell: (params) => params.value?.username || "Unknown",
+  },
+  {
+    field: "assignee",
+    headerName: "Assignee",
+    width: 150,
+    renderCell: (params) => params.value?.username || "Unassigned",
+  },
+];
+
+const TableView = ({ id }: TableViewProps) => {
+  const isDarkMode = useAppSelector((state) => state.global.isDarkMode);
+  const {
+    data: tasks,
+    isLoading,
+    error,
+  } = useGetTasksQuery({ projectId: Number(id) });
+
+  if (isLoading) return <div>Loading...</div>;
+  if (error) return <div>An error occured while fetching tasks</div>;
+
+  return (
+    <div className="h-[540px] w-full px-4 pb-8 xl:px-6">
+      <div className="pt-5">
+        <Header name="Table" isSmallText />
+        {/* TODO: button */}
+      </div>
+      <DataGrid
+        rows={tasks || []}
+        columns={columns}
+        className={dataGridClassNames}
+        sx={dataGridSxStyles(isDarkMode)}
+      />
+    </div>
+  );
+};
+
+export default TableView;

--- a/client/src/app/projects/TableView/index.tsx
+++ b/client/src/app/projects/TableView/index.tsx
@@ -78,8 +78,18 @@ const TableView = ({ id }: TableViewProps) => {
   return (
     <div className="h-[540px] w-full px-4 pb-8 xl:px-6">
       <div className="pt-5">
-        <Header name="Table" isSmallText />
-        {/* TODO: button */}
+        <Header
+          name="Table"
+          buttonComponent={
+            <button
+              className="flex items-center rounded bg-blue-primary px-3 py-2 text-white hover:bg-blue-600"
+              //TODO: onClick={()=>{}}
+            >
+              Add Task
+            </button>
+          }
+          isSmallText
+        />
       </div>
       <DataGrid
         rows={tasks || []}

--- a/client/src/app/projects/TimelineView/index.tsx
+++ b/client/src/app/projects/TimelineView/index.tsx
@@ -1,0 +1,92 @@
+import React, { useMemo, useState } from "react";
+import { useGetTasksQuery } from "@/state/api";
+import { useAppSelector } from "@/app/redux";
+import { DisplayOption, Gantt, ViewMode } from "gantt-task-react";
+import "gantt-task-react/dist/index.css";
+
+type TimelineViewProps = {
+  id: string;
+};
+
+type TaskTypeItems = "task" | "milestone" | "project";
+
+const TimelineView = ({ id }: TimelineViewProps) => {
+  const isDarkMode = useAppSelector((state) => state.global.isDarkMode);
+  const {
+    data: tasks,
+    error,
+    isLoading,
+  } = useGetTasksQuery({ projectId: Number(id) });
+
+  const [displayOptions, setDisplayOptions] = useState<DisplayOption>({
+    viewMode: ViewMode.Month,
+    locale: "en-US",
+  });
+
+  const ganttTasks = useMemo(() => {
+    return (
+      tasks?.map((task) => ({
+        start: new Date(task.startDate as string),
+        end: new Date(task.dueDate as string),
+        name: task.title,
+        id: `Task-${task.id}`,
+        type: "task" as TaskTypeItems,
+        progress: task.points ? (task.points / 10) * 100 : 0,
+        isDisabled: false,
+      })) || []
+    );
+  }, [tasks]);
+
+  const handleViewModeChange = (
+    event: React.ChangeEvent<HTMLSelectElement>,
+  ) => {
+    setDisplayOptions((prev) => ({
+      ...prev,
+      ViewMode: event.target.value as ViewMode,
+    }));
+  };
+
+  if (isLoading) return <div>Loading...</div>;
+  if (error) return <div>An error occured while fetching tasks</div>;
+
+  return (
+    <div className="px-4 xl:px-6">
+      <div className="flex flex-wrap items-center justify-between gap-2 py-5">
+        <h1 className="me-2 text-lg font-bold dark:text-white">
+          Project Tasks Timeline
+        </h1>
+        <div className="relative inline-block w-64">
+          <select
+            className="focus:shadow-outline block w-full appearance-none rounded border border-gray-400 bg-white px-4 py-2 pr-8 leading-tight shadow hover:border-gray-500 focus:outline-none dark:border-dark-secondary dark:bg-dark-secondary dark:text-white"
+            value={displayOptions.viewMode}
+            onChange={handleViewModeChange}
+          >
+            <option value={ViewMode.Day}>Day</option>
+            <option value={ViewMode.Week}>Week</option>
+            <option value={ViewMode.Month}>Month</option>
+          </select>
+        </div>
+      </div>
+
+      <div className="overflow-hidden rounded-md bg-white shadow dark:bg-dark-secondary dark:text-white">
+        <div className="timeline">
+          <Gantt
+            tasks={ganttTasks}
+            {...displayOptions}
+            columnWidth={displayOptions.viewMode === ViewMode.Month ? 150 : 100}
+            listCellWidth="100px"
+            barBackgroundColor={isDarkMode ? "#101214" : "#aeb8c2"}
+            barBackgroundSelectedColor={isDarkMode ? "#000" : "#9ba1a6"}
+          />
+        </div>
+        <div className="px-4 pb-5 pt-1">
+          <button className="flex items-center rounded bg-blue-primary px-3 py-2 text-white hover:bg-blue-600">
+            Add New Task
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default TimelineView;

--- a/client/src/app/projects/TimelineView/index.tsx
+++ b/client/src/app/projects/TimelineView/index.tsx
@@ -6,11 +6,12 @@ import "gantt-task-react/dist/index.css";
 
 type TimelineViewProps = {
   id: string;
+  setIsModalNewTaskOpen: (isOpen: boolean) => void;
 };
 
 type TaskTypeItems = "task" | "milestone" | "project";
 
-const TimelineView = ({ id }: TimelineViewProps) => {
+const TimelineView = ({ id, setIsModalNewTaskOpen }: TimelineViewProps) => {
   const isDarkMode = useAppSelector((state) => state.global.isDarkMode);
   const {
     data: tasks,
@@ -80,7 +81,10 @@ const TimelineView = ({ id }: TimelineViewProps) => {
           />
         </div>
         <div className="px-4 pb-5 pt-1">
-          <button className="flex items-center rounded bg-blue-primary px-3 py-2 text-white hover:bg-blue-600">
+          <button
+            className="flex items-center rounded bg-blue-primary px-3 py-2 text-white hover:bg-blue-600"
+            onClick={() => setIsModalNewTaskOpen(true)}
+          >
             Add New Task
           </button>
         </div>

--- a/client/src/app/projects/[id]/page.tsx
+++ b/client/src/app/projects/[id]/page.tsx
@@ -5,6 +5,7 @@ import ProjectHeader from "../ProjectHeader";
 import Board from "../BoardView";
 import List from "../ListView";
 import Timeline from "../TimelineView";
+import Table from "../TableView";
 
 type Props = {
   params: { id: string };
@@ -21,6 +22,7 @@ const Project = ({ params }: Props) => {
       {activeTab === "Board" && <Board id={id} />}
       {activeTab === "List" && <List id={id} />}
       {activeTab === "Timeline" && <Timeline id={id} />}
+      {activeTab === "Table" && <Table id={id} />}
     </div>
   );
 };

--- a/client/src/app/projects/[id]/page.tsx
+++ b/client/src/app/projects/[id]/page.tsx
@@ -6,6 +6,7 @@ import Board from "../BoardView";
 import List from "../ListView";
 import Timeline from "../TimelineView";
 import Table from "../TableView";
+import ModalNewTask from "@/app/components/ModalNewTask";
 
 type Props = {
   params: { id: string };
@@ -14,15 +15,28 @@ type Props = {
 const Project = ({ params }: Props) => {
   const { id } = params;
   const [activeTab, setActiveTab] = useState("Board");
+  const [isModalNewTaskOpen, setIsModalNewTaskOpen] = useState(false);
 
   return (
     <div>
-      {/* Modal NEW TASK */}
+      <ModalNewTask
+        isOpen={isModalNewTaskOpen}
+        onClose={() => setIsModalNewTaskOpen(false)}
+        id={id}
+      />
       <ProjectHeader activeTab={activeTab} setActiveTab={setActiveTab} />
-      {activeTab === "Board" && <Board id={id} />}
-      {activeTab === "List" && <List id={id} />}
-      {activeTab === "Timeline" && <Timeline id={id} />}
-      {activeTab === "Table" && <Table id={id} />}
+      {activeTab === "Board" && (
+        <Board id={id} setIsModalNewTaskOpen={setIsModalNewTaskOpen} />
+      )}
+      {activeTab === "List" && (
+        <List id={id} setIsModalNewTaskOpen={setIsModalNewTaskOpen} />
+      )}
+      {activeTab === "Timeline" && (
+        <Timeline id={id} setIsModalNewTaskOpen={setIsModalNewTaskOpen} />
+      )}
+      {activeTab === "Table" && (
+        <Table id={id} setIsModalNewTaskOpen={setIsModalNewTaskOpen} />
+      )}
     </div>
   );
 };

--- a/client/src/app/projects/[id]/page.tsx
+++ b/client/src/app/projects/[id]/page.tsx
@@ -4,6 +4,7 @@ import React, { useState } from "react";
 import ProjectHeader from "../ProjectHeader";
 import Board from "../BoardView";
 import List from "../ListView";
+import Timeline from "../TimelineView";
 
 type Props = {
   params: { id: string };
@@ -19,6 +20,7 @@ const Project = ({ params }: Props) => {
       <ProjectHeader activeTab={activeTab} setActiveTab={setActiveTab} />
       {activeTab === "Board" && <Board id={id} />}
       {activeTab === "List" && <List id={id} />}
+      {activeTab === "Timeline" && <Timeline id={id} />}
     </div>
   );
 };

--- a/client/src/app/projects/[id]/page.tsx
+++ b/client/src/app/projects/[id]/page.tsx
@@ -3,6 +3,7 @@
 import React, { useState } from "react";
 import ProjectHeader from "../ProjectHeader";
 import Board from "../BoardView";
+import List from "../ListView";
 
 type Props = {
   params: { id: string };
@@ -17,6 +18,7 @@ const Project = ({ params }: Props) => {
       {/* Modal NEW TASK */}
       <ProjectHeader activeTab={activeTab} setActiveTab={setActiveTab} />
       {activeTab === "Board" && <Board id={id} />}
+      {activeTab === "List" && <List id={id} />}
     </div>
   );
 };

--- a/client/src/lib/utils.ts
+++ b/client/src/lib/utils.ts
@@ -1,0 +1,32 @@
+export const dataGridClassNames =
+  "border border-gray-200 bg-white shadow dark:border-stroke-dark dark:bg-dark-secondary dark:text-gray-200";
+
+export const dataGridSxStyles = (isDarkMode: boolean) => {
+  return {
+    "& .MuiDataGrid-columnHeaders": {
+      color: `${isDarkMode ? "#e5e7eb" : ""}`,
+      '& [role="row"] > *': {
+        backgroundColor: `${isDarkMode ? "#1d1f21" : "white"}`,
+        borderColor: `${isDarkMode ? "#2d3135" : ""}`,
+      },
+    },
+    "& .MuiIconbutton-root": {
+      color: `${isDarkMode ? "#a3a3a3" : ""}`,
+    },
+    "& .MuiTablePagination-root": {
+      color: `${isDarkMode ? "#a3a3a3" : ""}`,
+    },
+    "& .MuiTablePagination-selectIcon": {
+      color: `${isDarkMode ? "#a3a3a3" : ""}`,
+    },
+    "& .MuiDataGrid-cell": {
+      border: "none",
+    },
+    "& .MuiDataGrid-row": {
+      borderBottom: `1px solid ${isDarkMode ? "#2d3135" : "e5e7eb"}`,
+    },
+    "& .MuiDataGrid-withBorderColor": {
+      borderColor: `${isDarkMode ? "#2d3135" : "e5e7eb"}`,
+    },
+  };
+};


### PR DESCRIPTION
- finished `Tasks` view options UI on a  `Project` page: `Board`, `List`, `Timeline`, `Table`
- created `New Project` and `New Task` modal forms:

  - new tasks can be added to `/projects/[projectId]` page
  - new projects can be added to the `Projects` list on the sidebar
  
  
 Suggestions: 
 - add more validation styles in both forms (highlight required fields and/or error message)
 - close modals on form submission
 - close modals by the click on overlay or `ESC`